### PR TITLE
MORPH-8242: Add OmegaIpamProvider with pool lifecycle and dataset provider

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 version=0.3.0-SNAPSHOT
 morpheusGradlePluginVersion=1.2.10
-morpheusApiVersion=1.3.0-SNAPSHOT
+morpheusApiVersion=1.3.2-SNAPSHOT
 groovyVersion=3.0.21
 slf4jVersion=1.7.26
 assetPipelineVersion=4.4.0

--- a/src/main/groovy/com/morpheusdata/omega/MorpheusOmegaTestPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/omega/MorpheusOmegaTestPlugin.groovy
@@ -18,6 +18,7 @@ package com.morpheusdata.omega
 import com.morpheusdata.omega.datasets.BaremetalHostsDataSetProvider
 import com.morpheusdata.omega.datasets.BaremetalResourcePoolDataSetProvider
 import com.morpheusdata.omega.datasets.CollectionDatasetProvider
+import com.morpheusdata.omega.datasets.OmegaIpamPoolServerDatasetProvider
 import com.morpheusdata.omega.addon.AddonPackageTestClusterTabProvider
 import com.morpheusdata.omega.addon.AddonPackageTypeProvider
 import com.morpheusdata.omega.baremetal.BaremetalCloudProvider
@@ -30,6 +31,7 @@ import com.morpheusdata.omega.process.ProcessServiceExampleCloudProvider
 import com.morpheusdata.omega.process.ProcessServiceExampleProvisionProvider
 import com.morpheusdata.omega.process.ProcessServiceExamplesDataSource
 import com.morpheusdata.omega.storage.OmegaStorageVolumeDetailProvider
+import com.morpheusdata.omega.ipam.OmegaIpamProvider
 import com.morpheusdata.omega.storageserver.StorageServerProvider
 import com.morpheusdata.core.Plugin
 
@@ -58,6 +60,8 @@ class MorpheusOmegaTestPlugin extends Plugin {
 
 		this.registerProvider(new StorageServerProvider(this,this.morpheus))
 
+		this.registerProvider(new OmegaIpamProvider(this, this.morpheus))
+
 		this.registerProvider(new DatastoreProvider(this, this.morpheus))
 
 		this.registerProvider(new EventGlobalSubscribingProvider(this,this.morpheus))
@@ -66,6 +70,7 @@ class MorpheusOmegaTestPlugin extends Plugin {
 		this.registerProvider(new CollectionDatasetProvider(this, this.morpheus))
 		this.registerProvider(new BaremetalHostsDataSetProvider(this,this.morpheus))
 		this.registerProvider(new BaremetalResourcePoolDataSetProvider(this,this.morpheus))
+		this.registerProvider(new OmegaIpamPoolServerDatasetProvider(this, this.morpheus))
 
 	}
 

--- a/src/main/groovy/com/morpheusdata/omega/datasets/OmegaIpamPoolServerDatasetProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/omega/datasets/OmegaIpamPoolServerDatasetProvider.groovy
@@ -1,0 +1,76 @@
+package com.morpheusdata.omega.datasets
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.data.DataQuery
+import com.morpheusdata.core.data.DatasetInfo
+import com.morpheusdata.core.data.DatasetQuery
+import com.morpheusdata.core.providers.AbstractDatasetProvider
+import com.morpheusdata.model.NetworkPoolServer
+import com.morpheusdata.omega.ipam.OmegaIpamProvider
+import io.reactivex.rxjava3.core.Observable
+
+class OmegaIpamPoolServerDatasetProvider extends AbstractDatasetProvider<NetworkPoolServer, Long> {
+	public static final String PROVIDER_NAME = 'Omega IPAM Pool Server Dataset Provider'
+	public static final String PROVIDER_NAMESPACE = 'com.omega.ipam'
+	public static final String PROVIDER_KEY = 'omega-ipam-pool-servers'
+	public static final String PROVIDER_DESCRIPTION = 'Omega IPAM pool server selector'
+
+	OmegaIpamPoolServerDatasetProvider(Plugin plugin, MorpheusContext morpheus) {
+		this.plugin = plugin
+		this.morpheusContext = morpheus
+	}
+
+	@Override
+	DatasetInfo getInfo() {
+		new DatasetInfo(
+			name: PROVIDER_NAME,
+			namespace: PROVIDER_NAMESPACE,
+			key: PROVIDER_KEY,
+			description: PROVIDER_DESCRIPTION
+		)
+	}
+
+	@Override
+	Class<NetworkPoolServer> getItemType() {
+		return NetworkPoolServer.class
+	}
+
+	@Override
+	Observable<NetworkPoolServer> list(DatasetQuery query) {
+		def listQuery = new DataQuery(query.user, query.parameters)
+		listQuery.withFilter('type.code', OmegaIpamProvider.IPAM_PROVIDER_CODE)
+		if(!listQuery.sort) {
+			listQuery.sort = 'name'
+		}
+		return morpheusContext.async.network.poolServer.list(listQuery)
+	}
+
+	@Override
+	Observable<Map> listOptions(DatasetQuery query) {
+		return list(query).map { [name: it.name, value: it.id] }
+	}
+
+	@Override
+	NetworkPoolServer fetchItem(Object value) {
+		def longValue = value instanceof Number ? value.toLong() : value?.toString()?.isLong() ? value.toString().toLong() : null
+		return longValue != null ? item(longValue) : null
+	}
+
+	@Override
+	NetworkPoolServer item(Long value) {
+		def query = new DataQuery().withFilter('id', value).withFilter('type.code', OmegaIpamProvider.IPAM_PROVIDER_CODE)
+		query.max = 1
+		return morpheusContext.services.network.poolServer.list(query)?.find()
+	}
+
+	@Override
+	String itemName(NetworkPoolServer item) {
+		return item.name
+	}
+
+	@Override
+	Long itemValue(NetworkPoolServer item) {
+		return item.id
+	}
+}

--- a/src/main/groovy/com/morpheusdata/omega/ipam/OmegaIpamProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/omega/ipam/OmegaIpamProvider.groovy
@@ -1,0 +1,258 @@
+package com.morpheusdata.omega.ipam
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.core.providers.IPAMProvider
+import com.morpheusdata.model.Icon
+import com.morpheusdata.model.NetworkDomain
+import com.morpheusdata.model.NetworkPool
+import com.morpheusdata.model.NetworkPoolIp
+import com.morpheusdata.model.NetworkPoolServer
+import com.morpheusdata.model.NetworkPoolType
+import com.morpheusdata.model.OptionType
+import com.morpheusdata.omega.datasets.OmegaIpamPoolServerDatasetProvider
+import com.morpheusdata.omega.logging.LogWrapper
+import com.morpheusdata.response.ServiceResponse
+import groovy.json.JsonOutput
+
+/**
+ * Omega test IPAM provider. Implements the full {@link IPAMProvider}
+ *
+ * All operations are no-ops that log their invocation and return success — this is intentional
+ * for a test/demo plugin.
+ */
+class OmegaIpamProvider implements IPAMProvider {
+
+	public static final String IPAM_PROVIDER_CODE = 'omega.ipam'
+
+	protected MorpheusContext morpheusContext
+	protected Plugin plugin
+	protected final LogWrapper log = LogWrapper.instance
+
+	OmegaIpamProvider(Plugin plugin, MorpheusContext morpheusContext) {
+		super()
+		this.plugin = plugin
+		this.morpheusContext = morpheusContext
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	MorpheusContext getMorpheus() {
+		return morpheusContext
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	Plugin getPlugin() {
+		return plugin
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	String getCode() {
+		return IPAM_PROVIDER_CODE
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	String getName() {
+		return 'Omega Test IPAM'
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	Icon getIcon() {
+		return new Icon(path: 'omega.svg', darkPath: 'omega-dark.svg')
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	List<OptionType> getIntegrationOptionTypes() {
+		return [
+			new OptionType(
+				code: 'omega.ipam.serviceUrl', name: 'serviceUrl',
+				category: 'networkPoolServer.omega.ipam',
+				fieldName: 'serviceUrl', fieldCode: 'gomorpheus.optiontype.Url', fieldLabel: 'URL',
+				fieldContext: 'domain', required: true, enabled: true, editable: true, global: false,
+				displayOrder: 0
+			),
+			new OptionType(
+				code: 'omega.ipam.credential', name: 'credentials',
+				optionSource: 'credentials',
+				category: 'networkPoolServer.omega.ipam',
+				fieldName: 'type', fieldCode: 'gomorpheus.label.credentials', fieldLabel: 'Credentials',
+				fieldContext: 'credential', required: true, enabled: true, editable: true, global: false,
+				displayOrder: 5, defaultValue: 'local',
+				config: JsonOutput.toJson(credentialTypes: ['username-password'])
+			),
+			new OptionType(
+				code: 'omega.ipam.serviceUsername', name: 'serviceUsername',
+				category: 'networkPoolServer.omega.ipam',
+				fieldName: 'serviceUsername', fieldCode: 'gomorpheus.optiontype.Username', fieldLabel: 'Username',
+				fieldContext: 'domain', required: false, enabled: true, editable: true, global: false,
+				displayOrder: 10, localCredential: true
+			),
+			new OptionType(
+				code: 'omega.ipam.servicePassword', name: 'servicePassword',
+				category: 'networkPoolServer.omega.ipam',
+				fieldName: 'servicePassword', fieldCode: 'gomorpheus.optiontype.Password', fieldLabel: 'Password',
+				fieldContext: 'domain', required: false, enabled: true, editable: true, global: false,
+				displayOrder: 15, localCredential: true
+			)
+		]
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	Collection<NetworkPoolType> getNetworkPoolTypes() {
+		return [
+			new NetworkPoolType(
+				code: 'omega.ipam.pool',
+				name: 'Omega IPAM Pool',
+				creatable: true,
+				description: 'Omega test IPAM pool type'
+			)
+		]
+	}
+
+	@Override
+	List<OptionType> getNetworkPoolOptionTypes() {
+		return [
+			new OptionType(
+				code: 'omega.ipam.pool.poolServer',
+				name: 'poolServer',
+				category: 'networkPool.omega.ipam.pool',
+				fieldName: 'poolServer',
+				fieldCode: 'gomorpheus.label.integration',
+				fieldLabel: 'Integration',
+				fieldContext: 'domain',
+				inputType: OptionType.InputType.SELECT,
+				required: true,
+				enabled: true,
+				editable: true,
+				global: false,
+				noBlank: true,
+				noSelection: 'Select',
+				displayOrder: 0,
+				optionSourceType: OmegaIpamPoolServerDatasetProvider.PROVIDER_NAMESPACE,
+				optionSource: OmegaIpamPoolServerDatasetProvider.PROVIDER_KEY
+			)
+		]
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse verifyNetworkPoolServer(NetworkPoolServer poolServer, Map opts) {
+		log.info("OmegaIpamProvider.verifyNetworkPoolServer: poolServer=${poolServer?.id}")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse createNetworkPoolServer(NetworkPoolServer poolServer, Map opts) {
+		log.info("OmegaIpamProvider.createNetworkPoolServer: poolServer=${poolServer?.id}")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse updateNetworkPoolServer(NetworkPoolServer poolServer, Map opts) {
+		log.info("OmegaIpamProvider.updateNetworkPoolServer: poolServer=${poolServer?.id}")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse initializeNetworkPoolServer(NetworkPoolServer poolServer, Map opts) {
+		log.info("OmegaIpamProvider.initializeNetworkPoolServer: poolServer=${poolServer?.id}")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	void refresh(NetworkPoolServer poolServer) {
+		log.info("OmegaIpamProvider.refresh: poolServer=${poolServer?.id}")
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse createNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		log.info("OmegaIpamProvider.createNetworkPool: poolServer=${poolServer?.id}, networkPool=${networkPool?.id} (${networkPool?.name})")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse updateNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		log.info("OmegaIpamProvider.updateNetworkPool: poolServer=${poolServer?.id}, networkPool=${networkPool?.id} (${networkPool?.name})")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse deleteNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		log.info("OmegaIpamProvider.deleteNetworkPool: poolServer=${poolServer?.id}, networkPool=${networkPool?.id} (${networkPool?.name})")
+		return ServiceResponse.success()
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse createHostRecord(NetworkPoolServer poolServer, NetworkPool networkPool, NetworkPoolIp networkPoolIp, NetworkDomain domain, Boolean createARecord, Boolean createPtrRecord) {
+		log.info("OmegaIpamProvider.createHostRecord: pool=${networkPool?.id}, ip=${networkPoolIp?.ipAddress}")
+		// Auto-assign a fake IP if none provided, to satisfy the contract
+		if (!networkPoolIp.ipAddress) {
+			networkPoolIp.ipAddress = '10.0.0.1'
+		}
+		return ServiceResponse.success(networkPoolIp)
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse updateHostRecord(NetworkPoolServer poolServer, NetworkPool networkPool, NetworkPoolIp networkPoolIp) {
+		log.info("OmegaIpamProvider.updateHostRecord: pool=${networkPool?.id}, ip=${networkPoolIp?.ipAddress}")
+		return ServiceResponse.success(networkPoolIp)
+	}
+
+  /**
+   * {@inheritDoc}
+   */
+	@Override
+	ServiceResponse deleteHostRecord(NetworkPool networkPool, NetworkPoolIp poolIp, Boolean deleteAssociatedRecords) {
+		log.info("OmegaIpamProvider.deleteHostRecord: pool=${networkPool?.id}, ip=${poolIp?.ipAddress}")
+		return ServiceResponse.success()
+	}
+}

--- a/src/main/groovy/com/morpheusdata/omega/ipam/OmegaIpamProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/omega/ipam/OmegaIpamProvider.groovy
@@ -124,32 +124,28 @@ class OmegaIpamProvider implements IPAMProvider {
 				code: 'omega.ipam.pool',
 				name: 'Omega IPAM Pool',
 				creatable: true,
-				description: 'Omega test IPAM pool type'
-			)
-		]
-	}
-
-	@Override
-	List<OptionType> getNetworkPoolOptionTypes() {
-		return [
-			new OptionType(
-				code: 'omega.ipam.pool.poolServer',
-				name: 'poolServer',
-				category: 'networkPool.omega.ipam.pool',
-				fieldName: 'poolServer',
-				fieldCode: 'gomorpheus.label.integration',
-				fieldLabel: 'Integration',
-				fieldContext: 'domain',
-				inputType: OptionType.InputType.SELECT,
-				required: true,
-				enabled: true,
-				editable: true,
-				global: false,
-				noBlank: true,
-				noSelection: 'Select',
-				displayOrder: 0,
-				optionSourceType: OmegaIpamPoolServerDatasetProvider.PROVIDER_NAMESPACE,
-				optionSource: OmegaIpamPoolServerDatasetProvider.PROVIDER_KEY
+				description: 'Omega test IPAM pool type',
+				optionTypes: [
+					new OptionType(
+						code: 'omega.ipam.pool.poolServer',
+						name: 'poolServer',
+						category: 'networkPool.omega.ipam.pool',
+						fieldName: 'poolServer',
+						fieldCode: 'gomorpheus.label.integration',
+						fieldLabel: 'Integration',
+						fieldContext: 'domain',
+						inputType: OptionType.InputType.SELECT,
+						required: true,
+						enabled: true,
+						editable: true,
+						global: false,
+						noBlank: true,
+						noSelection: 'Select',
+						displayOrder: 0,
+						optionSourceType: OmegaIpamPoolServerDatasetProvider.PROVIDER_NAMESPACE,
+						optionSource: OmegaIpamPoolServerDatasetProvider.PROVIDER_KEY
+					)
+				]
 			)
 		]
 	}


### PR DESCRIPTION
## Summary

- Implements `OmegaIpamProvider` — a test IPAM provider that exercises the new pool CRUD lifecycle hooks (`createNetworkPool`, `updateNetworkPool`, `deleteNetworkPool`) and provides a `poolServer` option type for the pool create/edit form.
- Adds `OmegaIpamPoolServerDatasetProvider` to scope the pool server dropdown to Omega-type integrations only.
- Bumps `morpheusApiVersion` to `1.3.2-SNAPSHOT`.

## Related PRs

- **morpheus-plugin-core**: https://github.com/HewlettPackard/morpheus-plugin-core/pull/139
- **morpheus-ui**: https://github.com/HPE-EMU/morpheus-ui/pull/3332